### PR TITLE
Add NL Chess example

### DIFF
--- a/examples/nl-chess/README.md
+++ b/examples/nl-chess/README.md
@@ -1,0 +1,20 @@
+# NL象棋 Example
+
+This example demonstrates a simple Chinese chess board with NodeLoc OAuth2 authentication using NextAuth.
+
+## Setup
+
+Create a `.env.local` file with your credentials:
+
+```
+NODELOC_CLIENT_ID=d91699453e85d61454ecca3f2e41b556
+NODELOC_CLIENT_SECRET=YOUR_SECRET
+NEXTAUTH_URL=http://localhost:3000
+```
+
+Install dependencies and run the development server:
+
+```bash
+pnpm install
+pnpm dev
+```

--- a/examples/nl-chess/app/api/auth/[...nextauth]/route.ts
+++ b/examples/nl-chess/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from "@/auth";

--- a/examples/nl-chess/app/board.module.css
+++ b/examples/nl-chess/app/board.module.css
@@ -1,0 +1,25 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+}
+.board {
+  display: grid;
+  grid-template-rows: repeat(10, 40px);
+  grid-template-columns: repeat(9, 40px);
+  gap: 2px;
+  border: 1px solid #333;
+}
+.row {
+  display: contents;
+}
+.cell {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #999;
+  cursor: pointer;
+}

--- a/examples/nl-chess/app/globals.css
+++ b/examples/nl-chess/app/globals.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}

--- a/examples/nl-chess/app/layout.tsx
+++ b/examples/nl-chess/app/layout.tsx
@@ -1,0 +1,9 @@
+import "./globals.css";
+import { ReactNode } from "react";
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/nl-chess/app/page.tsx
+++ b/examples/nl-chess/app/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useState } from "react";
+import styles from "./board.module.css";
+
+const initialBoard = [
+  ["r","n","b","a","k","a","b","n","r"],
+  ["","","","","","","","",""],
+  ["","c","","","","","","c",""],
+  ["p","","p","","p","","p","","p"],
+  ["","","","","","","","",""],
+  ["","","","","","","","",""],
+  ["P","","P","","P","","P","","P"],
+  ["","C","","","","","","C",""],
+  ["","","","","","","","",""],
+  ["R","N","B","A","K","A","B","N","R"],
+];
+
+export default function Home() {
+  const [board, setBoard] = useState(initialBoard);
+  const handleClick = (x: number, y: number) => {
+    console.log("Clicked", x, y);
+  };
+
+  return (
+    <div className={styles.container}>
+      <h1>NL象棋 Demo</h1>
+      <div className={styles.board}>
+        {board.map((row, y) => (
+          <div key={y} className={styles.row}>
+            {row.map((piece, x) => (
+              <div
+                key={x}
+                className={styles.cell}
+                onClick={() => handleClick(x, y)}
+              >
+                {piece}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/examples/nl-chess/auth.ts
+++ b/examples/nl-chess/auth.ts
@@ -1,0 +1,25 @@
+import NextAuth from "next-auth";
+import { OAuthConfig } from "next-auth/providers";
+
+const NodeLocProvider = {
+  id: "nodeloc",
+  name: "NodeLoc",
+  type: "oauth",
+  authorization: {
+    url: "http://conn.nodeloc.cc/oauth2/auth",
+    params: { scope: "openid profile" },
+  },
+  token: "http://conn.nodeloc.cc/oauth2/token",
+  userinfo: "http://conn.nodeloc.cc/oauth2/userinfo",
+  clientId: process.env.NODELOC_CLIENT_ID,
+  clientSecret: process.env.NODELOC_CLIENT_SECRET,
+} satisfies OAuthConfig<any>;
+
+export const {
+  handlers: { GET, POST },
+  auth,
+  signIn,
+  signOut,
+} = NextAuth({
+  providers: [NodeLocProvider],
+});

--- a/examples/nl-chess/next-env.d.ts
+++ b/examples/nl-chess/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/nl-chess/package.json
+++ b/examples/nl-chess/package.json
@@ -1,0 +1,20 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "next-auth": "^5.0.0-beta.4",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "typescript": "latest"
+  }
+}

--- a/examples/nl-chess/tsconfig.json
+++ b/examples/nl-chess/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add `examples/nl-chess` showcasing a minimal Chinese chess board
- demonstrate NodeLoc OAuth2 login with NextAuth

## Testing
- `pnpm --version` *(fails: unable to download due to network)*

------
https://chatgpt.com/codex/tasks/task_b_687c4503d7fc832ebaeb382b2fa72a81